### PR TITLE
Array support

### DIFF
--- a/examples/main.why
+++ b/examples/main.why
@@ -37,6 +37,12 @@ let bar: [[i32]] = [17, 42, 1337];
 
 let a = foo[0];
 
+fn some_function(): [i32] {
+    [42, 1337]
+}
+
+let b = (some_function())[42];
+
 // declare square: (i32) -> i32;
 
 // impl Add<i32, i32> {

--- a/examples/main.why
+++ b/examples/main.why
@@ -31,6 +31,12 @@ fn main(): i32 {
 
 let square: (i32) -> i32 = \(x) => x * x;
 
+let foo = [0; 10];
+
+let bar = [17, 42, 133
+
+let a = foo[0];
+
 // declare square: (i32) -> i32;
 
 // impl Add<i32, i32> {

--- a/examples/main.why
+++ b/examples/main.why
@@ -33,9 +33,9 @@ let square: (i32) -> i32 = \(x) => x * x;
 
 let foo = [0; 10];
 
-let bar = [17, 42, 133
+let bar: [[i32]] = [17, 42, 1337];
 
-let a = foo[0];
+// let a = foo[0];
 
 // declare square: (i32) -> i32;
 

--- a/examples/main.why
+++ b/examples/main.why
@@ -35,7 +35,7 @@ let foo = [0; 10];
 
 let bar: [[i32]] = [17, 42, 1337];
 
-// let a = foo[0];
+let a = foo[0];
 
 // declare square: (i32) -> i32;
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -31,6 +31,8 @@ lazy_static! {
         terminal!(m, RParen, ")");
         terminal!(m, LBrace, "{");
         terminal!(m, RBrace, "}");
+        terminal!(m, LBracket, "[");
+        terminal!(m, RBracket, "]");
         terminal!(m, FnKeyword, "fn");
         terminal!(m, IfKeyword, "if");
         terminal!(m, ElseKeyword, "else");

--- a/src/lexer/token_kind.rs
+++ b/src/lexer/token_kind.rs
@@ -62,6 +62,14 @@ pub enum TokenKind {
         position: Position,
     },
     #[terminal]
+    LBracket {
+        position: Position,
+    },
+    #[terminal]
+    RBracket {
+        position: Position,
+    },
+    #[terminal]
     FnKeyword {
         position: Position,
     },

--- a/src/parser/ast/expression/array.rs
+++ b/src/parser/ast/expression/array.rs
@@ -1,0 +1,126 @@
+use crate::{
+    lexer::{TokenKind, Tokens},
+    parser::{ast::AstNode, combinators::Comb, FromTokens, ParseError},
+};
+
+use super::{Expression, Num};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Array {
+    Literal {
+        values: Vec<Expression>,
+    },
+    Default {
+        initial_value: Box<Expression>,
+        length: Num,
+    },
+}
+
+impl FromTokens<TokenKind> for Array {
+    fn parse(tokens: &mut Tokens<TokenKind>) -> Result<AstNode, ParseError> {
+        let start = tokens.get_index();
+        let matcher = Comb::LBRACKET >> (Comb::EXPR % Comb::COMMA) >> Comb::RBRACKET;
+
+        if let Ok(result) = matcher.parse(tokens) {
+            let mut values = vec![];
+
+            for node in result {
+                let AstNode::Expression(value) = node else {
+                    unreachable!();
+                };
+                values.push(value);
+            }
+            return Ok(Array::Literal { values }.into());
+        }
+        tokens.set_index(start);
+
+        let matcher = Comb::LBRACKET >> Comb::EXPR >> Comb::SEMI >> Comb::NUM >> Comb::RBRACKET;
+        if let Ok(result) = matcher.parse(tokens) {
+            let Some(AstNode::Expression(initial_value)) = result.get(0).cloned() else {
+                unreachable!()
+            };
+
+            let Some(AstNode::Num(length)) = result.get(1).cloned() else {
+                unreachable!()
+            };
+
+            return Ok(Array::Default {
+                initial_value: Box::new(initial_value),
+                length,
+            }
+            .into());
+        };
+
+        Err(ParseError {
+            message: "failed to parse array initialization".into(),
+            position: None,
+        })
+    }
+}
+
+impl From<Array> for AstNode {
+    fn from(value: Array) -> Self {
+        Self::Array(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lexer::Lexer;
+
+    use super::*;
+
+    #[test]
+    fn test_empty_array() {
+        let mut tokens = Lexer::new("[]").lex().expect("something is wrong").into();
+
+        let result = Array::parse(&mut tokens);
+        assert_eq!(Ok(Array::Literal { values: vec![] }.into()), result);
+    }
+
+    #[test]
+    fn test_simple_literal() {
+        let mut tokens = Lexer::new("[42, 1337]")
+            .lex()
+            .expect("something is wrong")
+            .into();
+
+        let result = Array::parse(&mut tokens);
+        assert_eq!(
+            Ok(Array::Literal {
+                values: vec![Expression::Num(Num(42)), Expression::Num(Num(1337))]
+            }
+            .into()),
+            result
+        );
+    }
+
+    #[test]
+    fn test_simple_default() {
+        let mut tokens = Lexer::new("[42; 5]")
+            .lex()
+            .expect("something is wrong")
+            .into();
+
+        let result = Array::parse(&mut tokens);
+        assert_eq!(
+            Ok(Array::Default {
+                initial_value: Box::new(Expression::Num(Num(42))),
+                length: Num(5)
+            }
+            .into()),
+            result
+        );
+    }
+
+    #[test]
+    fn test_faulty_default() {
+        let mut tokens = Lexer::new("[42; ]")
+            .lex()
+            .expect("something is wrong")
+            .into();
+
+        let result = Array::parse(&mut tokens);
+        assert!(result.is_err());
+    }
+}

--- a/src/parser/ast/expression/postfix.rs
+++ b/src/parser/ast/expression/postfix.rs
@@ -6,4 +6,8 @@ pub enum Postfix {
         expr: Box<Expression>,
         args: Vec<Expression>,
     },
+    Index {
+        expr: Box<Expression>,
+        index: Box<Expression>,
+    },
 }

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -26,6 +26,7 @@ pub enum AstNode {
     Parameter(Parameter),
     TypeName(TypeName),
     Block(Block),
+    Array(Array),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -4,8 +4,8 @@ use crate::lexer::{Terminal, TokenKind, Tokens};
 
 use super::{
     ast::{
-        Assignment, AstNode, Block, Expression, Function, Id, If, Initialisation, Lambda, Num,
-        Parameter, Statement, TypeName, WhileLoop,
+        Array, Assignment, AstNode, Block, Expression, Function, Id, If, Initialisation, Lambda,
+        Num, Parameter, Statement, TypeName, WhileLoop,
     },
     FromTokens, ParseError,
 };
@@ -159,6 +159,10 @@ impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
 
     terminal_comb!(RBRACE, RBrace);
 
+    terminal_comb!(LBRACKET, LBracket);
+
+    terminal_comb!(RBRACKET, RBracket);
+
     terminal_comb!(FN_KEYWORD, FnKeyword);
 
     terminal_comb!(IF_KEYWORD, IfKeyword);
@@ -202,6 +206,8 @@ impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
     node_comb!(WHILE_LOOP, WhileLoop);
 
     node_comb!(BLOCK, Block);
+
+    node_comb!(ARRAY, Array);
 
     node_comb!(PARAMETER, Parameter);
 


### PR DESCRIPTION
This PR adds support for parsing array initialisations (both, literal and default), as well as indexing into an array and array type names.

The syntax is the following: 

```why
let foo: [i32] = [42; 5]; // 5 elements of type i32 with default value 42

let bar: [i32] = [ 1337, 42, 17 ]; // array literal

let a = bar[0]; // access value of bar at index 0 
```

Closes #7 