### PR TITLE
Declaration Support

### DIFF
--- a/examples/main.why
+++ b/examples/main.why
@@ -51,7 +51,7 @@ let also_takes_reference: (&i32) -> void = \(x) => {
     x = x + 10;
 };
 
-// declare square: (i32) -> i32;
+declare square: (i32) -> i32;
 
 // impl Add<i32, i32> {
 //     add = \(x, y) => x + y

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -49,6 +49,7 @@ lazy_static! {
         terminal!(m, GreaterOrEqual, ">=");
         terminal!(m, LessOrEqual, "<=");
         terminal!(m, Ampersand, "&");
+        terminal!(m, DeclareKeyword, "declare");
 
         m
     };

--- a/src/lexer/token_kind.rs
+++ b/src/lexer/token_kind.rs
@@ -133,4 +133,8 @@ pub enum TokenKind {
     Ampersand {
         position: Position,
     },
+    #[terminal]
+    DeclareKeyword {
+        position: Position,
+    },
 }

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -22,4 +22,5 @@ pub enum AstNode {
     TypeName(TypeName),
     Block(Block),
     Array(Array),
+    Declaration(Declaration),
 }

--- a/src/parser/ast/statement/declaration.rs
+++ b/src/parser/ast/statement/declaration.rs
@@ -1,0 +1,109 @@
+use crate::{
+    lexer::{TokenKind, Tokens},
+    parser::{
+        ast::{AstNode, Id, TypeName},
+        combinators::Comb,
+        FromTokens, ParseError,
+    },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Declaration {
+    pub name: Id,
+    pub type_name: TypeName,
+}
+
+impl FromTokens<TokenKind> for Declaration {
+    fn parse(tokens: &mut Tokens<TokenKind>) -> Result<AstNode, ParseError> {
+        let matcher = Comb::DECLARE_KEYWORD >> Comb::ID >> Comb::COLON >> Comb::TYPE_NAME;
+
+        let result = matcher.parse(tokens)?;
+
+        let Some(AstNode::Id(name)) = result.get(0).cloned() else {
+            unreachable!()
+        };
+
+        let Some(AstNode::TypeName(type_name)) = result.get(1).cloned() else {
+            unreachable!()
+        };
+
+        Ok(Declaration { name, type_name }.into())
+    }
+}
+
+impl From<Declaration> for AstNode {
+    fn from(value: Declaration) -> Self {
+        AstNode::Declaration(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        lexer::Lexer,
+        parser::{
+            ast::{Id, TypeName},
+            FromTokens,
+        },
+    };
+
+    use super::Declaration;
+
+    #[test]
+    fn test_parse_simple_declaration() {
+        let mut tokens = Lexer::new("declare foo: i32")
+            .lex()
+            .expect("something went wrong")
+            .into();
+
+        let result = Declaration::parse(&mut tokens);
+
+        assert_eq!(
+            Ok(Declaration {
+                name: Id("foo".into()),
+                type_name: TypeName::Literal("i32".into())
+            }
+            .into()),
+            result
+        )
+    }
+
+    #[test]
+    fn test_parse_tuple_declaration() {
+        let mut tokens = Lexer::new("declare foo: (i32, i32)")
+            .lex()
+            .expect("something went wrong")
+            .into();
+
+        let result = Declaration::parse(&mut tokens);
+        assert_eq!(
+            Ok(Declaration {
+                name: Id("foo".into()),
+                type_name: TypeName::Tuple(vec![TypeName::Literal("i32".into()); 2])
+            }
+            .into()),
+            result
+        )
+    }
+
+    #[test]
+    fn test_parse_function_declaration() {
+        let mut tokens = Lexer::new("declare foo: (i32, i32) -> i32")
+            .lex()
+            .expect("something went wrong")
+            .into();
+
+        let result = Declaration::parse(&mut tokens);
+        assert_eq!(
+            Ok(Declaration {
+                name: Id("foo".into()),
+                type_name: TypeName::Fn {
+                    params: vec![TypeName::Literal("i32".into()); 2],
+                    return_type: Box::new(TypeName::Literal("i32".into()))
+                }
+            }
+            .into()),
+            result
+        )
+    }
+}

--- a/src/parser/ast/statement/mod.rs
+++ b/src/parser/ast/statement/mod.rs
@@ -1,8 +1,10 @@
 mod assignment;
+mod declaration;
 mod initialisation;
 mod while_loop;
 
 pub use self::assignment::*;
+pub use self::declaration::*;
 pub use self::initialisation::*;
 pub use self::while_loop::*;
 
@@ -24,6 +26,7 @@ pub enum Statement {
     YieldingExpression(Expression),
     Return(Expression),
     Comment(String),
+    Declaration(Declaration),
 }
 
 impl FromTokens<TokenKind> for Statement {
@@ -80,6 +83,15 @@ impl FromTokens<TokenKind> for Statement {
                     unreachable!()
                 };
                 Ok(Statement::Return(expr.clone()).into())
+            }
+            TokenKind::DeclareKeyword { .. } => {
+                let matcher = Comb::DECLARATION >> Comb::SEMI;
+                let result = matcher.parse(tokens)?;
+
+                let Some(AstNode::Declaration(declaration)) = result.get(0).cloned() else {
+                    unreachable!()
+                };
+                Ok(Statement::Declaration(declaration).into())
             }
             TokenKind::Comment { value, .. } => {
                 tokens.next();

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -4,8 +4,8 @@ use crate::lexer::{Terminal, TokenKind, Tokens};
 
 use super::{
     ast::{
-        Array, Assignment, AstNode, Block, Expression, Function, Id, If, Initialisation, Lambda,
-        Num, Parameter, Statement, TypeName, WhileLoop,
+        Array, Assignment, AstNode, Block, Declaration, Expression, Function, Id, If,
+        Initialisation, Lambda, Num, Parameter, Statement, TypeName, WhileLoop,
     },
     FromTokens, ParseError,
 };
@@ -187,6 +187,8 @@ impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
 
     terminal_comb!(AMPERSAND, Ampersand);
 
+    terminal_comb!(DECLARE_KEYWORD, DeclareKeyword);
+
     node_comb!(ID, Id);
 
     node_comb!(NUM, Num);
@@ -214,6 +216,8 @@ impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
     node_comb!(PARAMETER, Parameter);
 
     node_comb!(TYPE_NAME, TypeName);
+
+    node_comb!(DECLARATION, Declaration);
 }
 
 impl<'a, Tok, Term, Node> Comb<'a, Tok, Term, Node>


### PR DESCRIPTION
This PR adds support for parsing declarations in the following form: 

```why
declare foo: (i32, i32) -> i32;
declare bar: i32;
```

closes #18 