### PR TITLE
Parse Constants

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -22,6 +22,7 @@ lazy_static! {
 
         terminal!(m, Eq, "=");
         terminal!(m, Let, "let");
+        terminal!(m, Const, "const");
         terminal!(m, Mut, "mut");
         terminal!(m, Semicolon, ";");
         terminal!(m, Plus, "+");

--- a/src/lexer/token_kind.rs
+++ b/src/lexer/token_kind.rs
@@ -13,6 +13,10 @@ pub enum TokenKind {
         position: Position,
     },
     #[terminal]
+    Const {
+        position: Position,
+    },
+    #[terminal]
     Mut {
         position: Position,
     },

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -13,6 +13,7 @@ pub enum AstNode {
     Num(Num),
     Statement(Statement),
     Initialization(Initialisation),
+    Constant(Constant),
     Assignment(Assignment),
     Function(Function),
     Lambda(Lambda),

--- a/src/parser/ast/statement/constant.rs
+++ b/src/parser/ast/statement/constant.rs
@@ -1,0 +1,80 @@
+use crate::{
+    lexer::{TokenKind, Tokens},
+    parser::{
+        ast::{AstNode, Expression, Id, TypeName},
+        combinators::Comb,
+        FromTokens, ParseError,
+    },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Constant {
+    pub id: Id,
+    pub type_name: TypeName,
+    pub value: Expression,
+}
+
+impl FromTokens<TokenKind> for Constant {
+    fn parse(tokens: &mut Tokens<TokenKind>) -> Result<AstNode, ParseError>
+    where
+        Self: Sized,
+    {
+        Comb::CONST_KEYWORD.parse(tokens)?;
+
+        let matcher = Comb::ID >> Comb::COLON >> Comb::TYPE_NAME >> Comb::EQ >> Comb::EXPR;
+
+        let result = matcher.parse(tokens)?;
+
+        let Some(AstNode::Id(id)) = result.get(0) else {
+            unreachable!()
+        };
+
+        let Some(AstNode::TypeName(type_name)) = result.get(1).cloned() else {
+            unreachable!()
+        };
+
+        let Some(AstNode::Expression(value)) = result.get(2).cloned() else {
+            unreachable!()
+        };
+
+        Ok(Constant {
+            id: id.clone(),
+            value: value.clone(),
+            type_name,
+        }
+        .into())
+    }
+}
+
+impl From<Constant> for AstNode {
+    fn from(value: Constant) -> Self {
+        AstNode::Constant(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{lexer::Lexer, parser::ast::Num};
+
+    use super::*;
+
+    #[test]
+    fn test_simple_constant() {
+        let mut tokens = Lexer::new("const foo: i32 = 42")
+            .lex()
+            .expect("should work")
+            .into();
+
+        let result = Constant::parse(&mut tokens);
+
+        assert_eq!(
+            Ok(Constant {
+                id: Id("foo".into()),
+                type_name: TypeName::Literal("i32".into()),
+                value: Expression::Num(Num(42))
+            }
+            .into()),
+            result
+        )
+    }
+}

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -4,7 +4,7 @@ use crate::lexer::{Terminal, TokenKind, Tokens};
 
 use super::{
     ast::{
-        Array, Assignment, AstNode, Block, Declaration, Expression, Function, Id, If,
+        Array, Assignment, AstNode, Block, Constant, Declaration, Expression, Function, Id, If,
         Initialisation, Lambda, Num, Parameter, Statement, TypeName, WhileLoop,
     },
     FromTokens, ParseError,
@@ -147,6 +147,8 @@ macro_rules! node_comb {
 impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
     terminal_comb!(LET, Let);
 
+    terminal_comb!(CONST_KEYWORD, Const);
+
     terminal_comb!(MUT, Mut);
 
     terminal_comb!(EQ, Eq);
@@ -218,6 +220,8 @@ impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
     node_comb!(TYPE_NAME, TypeName);
 
     node_comb!(DECLARATION, Declaration);
+
+    node_comb!(CONSTANT, Constant);
 }
 
 impl<'a, Tok, Term, Node> Comb<'a, Tok, Term, Node>


### PR DESCRIPTION
This PR adds support to parse constants in the following form: 

```why
const foo: i32 = 42;
```

Closes #8 