### PR TITLE
Parser: Struct Support

### DIFF
--- a/examples/main.why
+++ b/examples/main.why
@@ -41,7 +41,7 @@ fn some_function(): [i32] {
     [42, 1337]
 }
 
-let b = (some_function())[42];
+let b = some_function()[42];
 
 fn takes_reference(x: &i32): void {
     x = x + 10;
@@ -55,6 +55,14 @@ declare square: (i32) -> i32;
 
 const PI: f32 = 314159265;
 
-// impl Add<i32, i32> {
-//     add = \(x, y) => x + y
-// }
+struct Foo {
+    bar: u32;
+    baz: u64;
+};
+
+// let foo = Foo {
+//    bar: 123,
+//    baz: 42
+// };
+
+// let test = foo.bar;

--- a/examples/main.why
+++ b/examples/main.why
@@ -65,4 +65,4 @@ let foo = Foo {
    baz: 42
 };
 
-// let test = foo.bar;
+let test = foo.bar()[42];

--- a/examples/main.why
+++ b/examples/main.why
@@ -10,7 +10,7 @@ fn main(): i32 {
     let foo = test(42);
     let bar = foo(1337);
 
-    if true {
+    if (true) {
         bar()
     } else {
         foo()
@@ -18,7 +18,7 @@ fn main(): i32 {
 
     let mut x = 10;
 
-    while x > 0 {
+    while (x > 0) {
         do_something(x);
         x = x - 1;
     }
@@ -60,9 +60,9 @@ struct Foo {
     baz: u64;
 };
 
-// let foo = Foo {
-//    bar: 123,
-//    baz: 42
-// };
+let foo = Foo {
+   bar: 123,
+   baz: 42
+};
 
 // let test = foo.bar;

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -41,6 +41,7 @@ lazy_static! {
         terminal!(m, ReturnKeyword, "return");
         terminal!(m, Colon, ":");
         terminal!(m, Comma, ",");
+        terminal!(m, Dot, ".");
         terminal!(m, SmallRightArrow, "->");
         terminal!(m, BigRightArrow, "=>");
         terminal!(m, Backslash, "\\");
@@ -51,6 +52,7 @@ lazy_static! {
         terminal!(m, LessOrEqual, "<=");
         terminal!(m, Ampersand, "&");
         terminal!(m, DeclareKeyword, "declare");
+        terminal!(m, StructKeyword, "struct");
 
         m
     };

--- a/src/lexer/token_kind.rs
+++ b/src/lexer/token_kind.rs
@@ -101,6 +101,10 @@ pub enum TokenKind {
         position: Position,
     },
     #[terminal]
+    Dot {
+        position: Position,
+    },
+    #[terminal]
     SmallRightArrow {
         position: Position,
     },
@@ -138,6 +142,10 @@ pub enum TokenKind {
     },
     #[terminal]
     DeclareKeyword {
+        position: Position,
+    },
+    #[terminal]
+    StructKeyword {
         position: Position,
     },
 }

--- a/src/parser/ast/expression/if_expression.rs
+++ b/src/parser/ast/expression/if_expression.rs
@@ -21,7 +21,9 @@ impl FromTokens<TokenKind> for If {
         tokens: &mut crate::lexer::Tokens<TokenKind>,
     ) -> Result<crate::parser::ast::AstNode, crate::parser::ParseError> {
         let matcher = Comb::IF_KEYWORD
+            >> Comb::LPAREN
             >> Comb::EXPR
+            >> Comb::RPAREN
             >> Comb::LBRACE
             >> (Comb::STATEMENT ^ ())
             >> Comb::RBRACE;
@@ -79,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_simple_if() {
-        let mut tokens = Lexer::new("if x {}").lex().expect("should work").into();
+        let mut tokens = Lexer::new("if (x) {}").lex().expect("should work").into();
 
         assert_eq!(
             Ok(If {
@@ -94,7 +96,7 @@ mod tests {
 
     #[test]
     fn test_simple_if_else() {
-        let mut tokens = Lexer::new("if x {} else {}")
+        let mut tokens = Lexer::new("if (x) {} else {}")
             .lex()
             .expect("should work")
             .into();
@@ -112,7 +114,7 @@ mod tests {
 
     #[test]
     fn test_complexer_if() {
-        let mut tokens = Lexer::new("if x { 3 + 4 }")
+        let mut tokens = Lexer::new("if (x) { 3 + 4 }")
             .lex()
             .expect("should work")
             .into();
@@ -133,7 +135,7 @@ mod tests {
 
     #[test]
     fn test_complexer_if_else() {
-        let mut tokens = Lexer::new("if x { 3 + 4 } else { 42 + 1337 }")
+        let mut tokens = Lexer::new("if (x) { 3 + 4 } else { 42 + 1337 }")
             .lex()
             .expect("should work")
             .into();

--- a/src/parser/ast/expression/postfix.rs
+++ b/src/parser/ast/expression/postfix.rs
@@ -1,4 +1,4 @@
-use super::Expression;
+use super::{Expression, Id};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Postfix {
@@ -9,5 +9,9 @@ pub enum Postfix {
     Index {
         expr: Box<Expression>,
         index: Box<Expression>,
+    },
+    PropertyAccess {
+        expr: Box<Expression>,
+        property: Id,
     },
 }

--- a/src/parser/ast/expression/struct_initialisation.rs
+++ b/src/parser/ast/expression/struct_initialisation.rs
@@ -1,0 +1,185 @@
+use crate::{
+    lexer::{TokenKind, Tokens},
+    parser::{ast::AstNode, combinators::Comb, FromTokens, ParseError},
+};
+
+use super::{Expression, Id};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructInitialisation {
+    pub id: Id,
+    pub fields: Vec<StructFieldInitialisation>,
+}
+
+impl FromTokens<TokenKind> for StructInitialisation {
+    fn parse(tokens: &mut Tokens<TokenKind>) -> Result<AstNode, ParseError> {
+        let matcher = Comb::ID
+            >> Comb::LBRACE
+            >> (Comb::STRUCT_FIELD_INITIALISATION % Comb::COMMA)
+            >> Comb::RBRACE;
+
+        let mut result = matcher.parse(tokens)?.into_iter();
+
+        let Some(AstNode::Id(id)) = result.next() else {
+            unreachable!();
+        };
+
+        let mut fields = vec![];
+
+        while let Some(AstNode::StructFieldInitialisation(field)) = result.next() {
+            fields.push(field);
+        }
+
+        Ok(StructInitialisation { id, fields }.into())
+    }
+}
+
+impl From<StructInitialisation> for AstNode {
+    fn from(value: StructInitialisation) -> Self {
+        Self::StructInitialisation(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructFieldInitialisation {
+    pub name: Id,
+    pub value: Expression,
+}
+
+impl FromTokens<TokenKind> for StructFieldInitialisation {
+    fn parse(tokens: &mut Tokens<TokenKind>) -> Result<AstNode, ParseError> {
+        let matcher = Comb::ID >> Comb::COLON >> Comb::EXPR;
+
+        let result = matcher.parse(tokens)?;
+
+        let Some(AstNode::Id(name)) = result.first() else {
+            unreachable!();
+        };
+
+        let Some(AstNode::Expression(value)) = result.get(1) else {
+            unreachable!();
+        };
+
+        Ok(StructFieldInitialisation {
+            name: name.clone(),
+            value: value.clone(),
+        }
+        .into())
+    }
+}
+
+impl From<StructFieldInitialisation> for AstNode {
+    fn from(value: StructFieldInitialisation) -> Self {
+        Self::StructFieldInitialisation(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        lexer::Lexer,
+        parser::{
+            ast::{Expression, Id, Lambda, Num, Parameter},
+            FromTokens,
+        },
+    };
+
+    use super::{StructFieldInitialisation, StructInitialisation};
+
+    #[test]
+    fn parse_simple_struct_field_initialisation() {
+        let mut tokens = Lexer::new("bar: 42")
+            .lex()
+            .expect("something is wrong")
+            .into();
+
+        let result = StructFieldInitialisation::parse(&mut tokens);
+
+        assert_eq!(
+            Ok(StructFieldInitialisation {
+                name: Id("bar".into()),
+                value: Expression::Num(Num(42))
+            }
+            .into()),
+            result
+        )
+    }
+
+    #[test]
+    fn parse_simple_struct_initialisation() {
+        let mut tokens = Lexer::new("Foo {}")
+            .lex()
+            .expect("something is wrong")
+            .into();
+
+        let result = StructInitialisation::parse(&mut tokens);
+
+        assert_eq!(
+            Ok(StructInitialisation {
+                id: Id("Foo".into()),
+                fields: vec![]
+            }
+            .into()),
+            result
+        );
+    }
+
+    #[test]
+    fn parse_struct_initialisation_with_one_field() {
+        let mut tokens = Lexer::new("Foo { bar: 42 }")
+            .lex()
+            .expect("something is wrong")
+            .into();
+
+        let result = StructInitialisation::parse(&mut tokens);
+
+        assert_eq!(
+            Ok(StructInitialisation {
+                id: Id("Foo".into()),
+                fields: vec![StructFieldInitialisation {
+                    name: Id("bar".into()),
+                    value: Expression::Num(Num(42))
+                }]
+            }
+            .into()),
+            result
+        );
+    }
+
+    #[test]
+    fn parse_struct_initialisation_with_multiple_fields() {
+        let mut tokens = Lexer::new("Foo { bar: 42, baz: \\(x) => x + x }")
+            .lex()
+            .expect("something is wrong")
+            .into();
+
+        let result = StructInitialisation::parse(&mut tokens);
+
+        assert_eq!(
+            Ok(StructInitialisation {
+                id: Id("Foo".into()),
+                fields: vec![
+                    StructFieldInitialisation {
+                        name: Id("bar".into()),
+                        value: Expression::Num(Num(42))
+                    },
+                    StructFieldInitialisation {
+                        name: Id("baz".into()),
+                        value: Expression::Lambda(Lambda {
+                            parameters: vec![Parameter {
+                                name: Id("x".into()),
+                                type_name: None
+                            }],
+                            expression: Box::new(Expression::Addition(
+                                Box::new(Expression::Id(Id("x".into()))),
+                                Box::new(Expression::Id(Id("x".into())))
+                            ))
+                        })
+                    }
+                ]
+            }
+            .into()),
+            result
+        );
+    }
+}

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -26,4 +26,6 @@ pub enum AstNode {
     Declaration(Declaration),
     StructDeclaration(StructDeclaration),
     StructFieldDeclaration(StructFieldDeclaration),
+    StructInitialisation(StructInitialisation),
+    StructFieldInitialisation(StructFieldInitialisation),
 }

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -24,4 +24,6 @@ pub enum AstNode {
     Block(Block),
     Array(Array),
     Declaration(Declaration),
+    StructDeclaration(StructDeclaration),
+    StructFieldDeclaration(StructFieldDeclaration),
 }

--- a/src/parser/ast/statement/mod.rs
+++ b/src/parser/ast/statement/mod.rs
@@ -2,12 +2,14 @@ mod assignment;
 mod constant;
 mod declaration;
 mod initialisation;
+mod struct_declaration;
 mod while_loop;
 
 pub use self::assignment::*;
 pub use self::constant::*;
 pub use self::declaration::*;
 pub use self::initialisation::*;
+pub use self::struct_declaration::*;
 pub use self::while_loop::*;
 
 use crate::{
@@ -30,6 +32,7 @@ pub enum Statement {
     Return(Expression),
     Comment(String),
     Declaration(Declaration),
+    StructDeclaration(StructDeclaration),
 }
 
 impl FromTokens<TokenKind> for Statement {
@@ -108,6 +111,15 @@ impl FromTokens<TokenKind> for Statement {
             TokenKind::Comment { value, .. } => {
                 tokens.next();
                 Ok(Statement::Comment(value).into())
+            }
+            TokenKind::StructKeyword { .. } => {
+                let matcher = Comb::STRUCT_DECLARATION >> Comb::SEMI;
+                let result = matcher.parse(tokens)?;
+
+                let Some(AstNode::StructDeclaration(declaration)) = result.first().cloned() else {
+                    unreachable!()
+                };
+                Ok(Statement::StructDeclaration(declaration).into())
             }
             _ => {
                 if let Ok(assignment) = Self::parse_assignment(tokens) {

--- a/src/parser/ast/statement/mod.rs
+++ b/src/parser/ast/statement/mod.rs
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_if_else_without_semicolon() {
-        let mut tokens = Lexer::new("if x { 3 + 4 } else { 42 + 1337 }")
+        let mut tokens = Lexer::new("if (x) { 3 + 4 } else { 42 + 1337 }")
             .lex()
             .expect("should work")
             .into();
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn test_if_else_with_semicolon() {
-        let mut tokens = Lexer::new("if x { 3 + 4 } else { 42 + 1337 };")
+        let mut tokens = Lexer::new("if (x) { 3 + 4 } else { 42 + 1337 };")
             .lex()
             .expect("should work")
             .into();
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn test_if_else_ignores_call() {
-        let mut tokens = Lexer::new("if x { 3 + 4 } else { 42 + 1337 }()")
+        let mut tokens = Lexer::new("if (x) { 3 + 4 } else { 42 + 1337 }()")
             .lex()
             .expect("should work")
             .into();

--- a/src/parser/ast/statement/struct_declaration.rs
+++ b/src/parser/ast/statement/struct_declaration.rs
@@ -1,0 +1,168 @@
+use crate::{
+    lexer::{TokenKind, Tokens},
+    parser::{
+        ast::{AstNode, Id, TypeName},
+        combinators::Comb,
+        FromTokens, ParseError,
+    },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructDeclaration {
+    id: Id,
+    fields: Vec<StructFieldDeclaration>,
+}
+
+impl FromTokens<TokenKind> for StructDeclaration {
+    fn parse(tokens: &mut Tokens<TokenKind>) -> Result<AstNode, ParseError> {
+        let matcher = Comb::STRUCT_KEYWORD
+            >> Comb::ID
+            >> Comb::LBRACE
+            >> (Comb::STRUCT_FIELD_DECLARATION ^ ())
+            >> Comb::RBRACE;
+
+        let mut result = matcher.parse(tokens)?.into_iter();
+
+        let Some(AstNode::Id(id)) = result.next() else {
+            unreachable!()
+        };
+
+        let mut fields = vec![];
+
+        while let Some(AstNode::StructFieldDeclaration(field)) = result.next() {
+            fields.push(field);
+        }
+
+        Ok(StructDeclaration { id, fields }.into())
+    }
+}
+
+impl From<StructDeclaration> for AstNode {
+    fn from(value: StructDeclaration) -> Self {
+        Self::StructDeclaration(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructFieldDeclaration {
+    name: Id,
+    type_name: TypeName,
+}
+
+impl FromTokens<TokenKind> for StructFieldDeclaration {
+    fn parse(tokens: &mut Tokens<TokenKind>) -> Result<AstNode, ParseError> {
+        let matcher = Comb::ID >> Comb::COLON >> Comb::TYPE_NAME >> Comb::SEMI;
+        let result = matcher.parse(tokens)?;
+
+        let Some(AstNode::Id(name)) = result.first() else {
+            unreachable!()
+        };
+
+        let Some(AstNode::TypeName(type_name)) = result.get(1) else {
+            unreachable!()
+        };
+
+        Ok(StructFieldDeclaration {
+            name: name.clone(),
+            type_name: type_name.clone(),
+        }
+        .into())
+    }
+}
+
+impl From<StructFieldDeclaration> for AstNode {
+    fn from(value: StructFieldDeclaration) -> Self {
+        Self::StructFieldDeclaration(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        lexer::Lexer,
+        parser::{
+            ast::{Id, StructFieldDeclaration, TypeName},
+            FromTokens,
+        },
+    };
+
+    use super::StructDeclaration;
+
+    #[test]
+    fn parse_empty_struct() {
+        let mut tokens = Lexer::new("struct Foo {}")
+            .lex()
+            .expect("something is wrong")
+            .into();
+
+        let result = StructDeclaration::parse(&mut tokens);
+
+        assert_eq!(
+            Ok(StructDeclaration {
+                id: Id("Foo".into()),
+                fields: vec![]
+            }
+            .into()),
+            result
+        );
+    }
+
+    #[test]
+    fn parse_struct_with_single_field() {
+        let mut tokens = Lexer::new(
+            "struct Foo {
+            foo: u32;
+        }",
+        )
+        .lex()
+        .expect("something is wrong")
+        .into();
+
+        let result = StructDeclaration::parse(&mut tokens);
+
+        assert_eq!(
+            Ok(StructDeclaration {
+                id: Id("Foo".into()),
+                fields: vec![StructFieldDeclaration {
+                    name: Id("foo".into()),
+                    type_name: TypeName::Literal("u32".into())
+                }]
+            }
+            .into()),
+            result
+        );
+    }
+
+    #[test]
+    fn parse_struct_with_multiple_fields() {
+        let mut tokens = Lexer::new(
+            "struct Foo {
+            foo: u32;
+            baz: [f64];
+        }",
+        )
+        .lex()
+        .expect("something is wrong")
+        .into();
+
+        let result = StructDeclaration::parse(&mut tokens);
+
+        assert_eq!(
+            Ok(StructDeclaration {
+                id: Id("Foo".into()),
+                fields: vec![
+                    StructFieldDeclaration {
+                        name: Id("foo".into()),
+                        type_name: TypeName::Literal("u32".into())
+                    },
+                    StructFieldDeclaration {
+                        name: Id("baz".into()),
+                        type_name: TypeName::Array(Box::new(TypeName::Literal("f64".into())))
+                    }
+                ]
+            }
+            .into()),
+            result
+        );
+    }
+}

--- a/src/parser/ast/statement/while_loop.rs
+++ b/src/parser/ast/statement/while_loop.rs
@@ -15,7 +15,8 @@ pub struct WhileLoop {
 
 impl FromTokens<TokenKind> for WhileLoop {
     fn parse(tokens: &mut Tokens<TokenKind>) -> Result<AstNode, ParseError> {
-        let matcher = Comb::WHILE_KEYWORD >> Comb::EXPR >> Comb::BLOCK;
+        let matcher =
+            Comb::WHILE_KEYWORD >> Comb::LPAREN >> Comb::EXPR >> Comb::RPAREN >> Comb::BLOCK;
 
         let result = matcher.parse(tokens)?;
 

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -5,7 +5,8 @@ use crate::lexer::{Terminal, TokenKind, Tokens};
 use super::{
     ast::{
         Array, Assignment, AstNode, Block, Constant, Declaration, Expression, Function, Id, If,
-        Initialisation, Lambda, Num, Parameter, Statement, TypeName, WhileLoop,
+        Initialisation, Lambda, Num, Parameter, Statement, StructDeclaration,
+        StructFieldDeclaration, TypeName, WhileLoop,
     },
     FromTokens, ParseError,
 };
@@ -191,6 +192,8 @@ impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
 
     terminal_comb!(DECLARE_KEYWORD, DeclareKeyword);
 
+    terminal_comb!(STRUCT_KEYWORD, StructKeyword);
+
     node_comb!(ID, Id);
 
     node_comb!(NUM, Num);
@@ -222,6 +225,10 @@ impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
     node_comb!(DECLARATION, Declaration);
 
     node_comb!(CONSTANT, Constant);
+
+    node_comb!(STRUCT_DECLARATION, StructDeclaration);
+
+    node_comb!(STRUCT_FIELD_DECLARATION, StructFieldDeclaration);
 }
 
 impl<'a, Tok, Term, Node> Comb<'a, Tok, Term, Node>

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -181,6 +181,8 @@ impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
 
     terminal_comb!(COMMA, Comma);
 
+    terminal_comb!(DOT, Dot);
+
     terminal_comb!(SEMI, Semicolon);
 
     terminal_comb!(SMALL_RIGHT_ARROW, SmallRightArrow);

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -6,7 +6,8 @@ use super::{
     ast::{
         Array, Assignment, AstNode, Block, Constant, Declaration, Expression, Function, Id, If,
         Initialisation, Lambda, Num, Parameter, Statement, StructDeclaration,
-        StructFieldDeclaration, TypeName, WhileLoop,
+        StructFieldDeclaration, StructFieldInitialisation, StructInitialisation, TypeName,
+        WhileLoop,
     },
     FromTokens, ParseError,
 };
@@ -229,6 +230,10 @@ impl<'a> Comb<'a, TokenKind, Terminal, AstNode> {
     node_comb!(STRUCT_DECLARATION, StructDeclaration);
 
     node_comb!(STRUCT_FIELD_DECLARATION, StructFieldDeclaration);
+
+    node_comb!(STRUCT_INITILISATION, StructInitialisation);
+
+    node_comb!(STRUCT_FIELD_INITIALISATION, StructFieldInitialisation);
 }
 
 impl<'a, Tok, Term, Node> Comb<'a, Tok, Term, Node>


### PR DESCRIPTION
This PR adds support for parsing structs. Furthermore, it introduces the requirement to surround expressions in the conditions of `if` and `while` statements with parenthesis. 

Closes #6 